### PR TITLE
Name the include_vars task

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,7 +6,8 @@
     that: "vsftpd_listen != vsftpd_listen_ipv6"
   tags: vsftpd
 
-- include_vars: "{{ item }}"
+- name: Include OS-specific variables
+  include_vars: "{{ item }}"
   with_first_found:
     - "{{ ansible_os_family }}.yml"
     - default.yml


### PR DESCRIPTION
"All tasks should be named", saith the linter.