### PR TITLE
Do not start service until config file is applied

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,13 +21,6 @@
 - include_tasks: selinux.yml
   when: ansible_selinux is defined and ansible_selinux != false and ansible_selinux.status == 'enabled'
 
-- name: Ensure service is started
-  service:
-    name: '{{ vsftpd_service }}'
-    state: started
-    enabled: true
-  tags: vsftpd
-
 - name: Ensure `anon_root` exists
   file:
     path: '{{ vsftpd_anon_root }}'
@@ -58,4 +51,11 @@
     #validate: 'vsftpd -olisten=NO %s'
     #  validation always exits with status 1, even if everything seems ok
   notify: restart vsftpd
+  tags: vsftpd
+
+- name: Ensure service is started
+  service:
+    name: '{{ vsftpd_service }}'
+    state: started
+    enabled: true
   tags: vsftpd


### PR DESCRIPTION
Postpone starting the service until our config file is written out. This prevents starting with the default config (which may be less secure than you want), and allows you to reinstall if the server cannot start because the config file is currently broken.