### PR TITLE
White- & blacklist + chroot_local_user

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,3 +13,5 @@ vsftpd_owner: root
 vsftpd_setype: public_content_t
 vsftpd_syslog_enable: true
 vsftpd_write_enable: true
+vsftpd_userlist_whitelist: true
+vsftpd_chroot_local_user: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -53,6 +53,15 @@
     #  validation always exits with status 1, even if everything seems ok
   notify: restart vsftpd
   tags: vsftpd
+  
+- name: Install userlist file
+  template:
+    src:   "{{vsftpd_userlist}}"
+    dest: "{{ vsftpd_userlist_file }}"
+    mode: '0600'
+  when: vsftpd_userlist is defined
+  notify: restart vsftpd
+  tags: vsftpd
 
 - name: Add extra (ACL) permissions
   acl:

--- a/templates/etc_vsftpd_user_list.j2
+++ b/templates/etc_vsftpd_user_list.j2
@@ -1,0 +1,8 @@
+# Vsftpd userlist
+# Managed by Ansible, don't edit manually
+# 
+# Add every user you want to whitelist on a new line
+svena
+keanu
+stevenh
+leend

--- a/templates/etc_vsftpd_vsftpd.conf.j2
+++ b/templates/etc_vsftpd_vsftpd.conf.j2
@@ -33,6 +33,16 @@ write_enable={{ 'YES' if vsftpd_write_enable else 'NO' }}
 seccomp_sandbox=NO
 {% endif %}
 
+chroot_local_user={{ 'YES' if vsftpd_chroot_local_user else 'NO' }}
+
+{% if vsftpd_userlist is defined %}
+# 
+# Whitelist (if userlist_deny=NO) -- Blacklist (if userlist_deny=YES)
+# 
+userlist_enable=YES
+userlist_deny={{ 'NO' if vsftpd_userlist_whitelist else 'YES' }}
+{% endif %}
+
 {% if vsftpd_options is defined %}
 #
 # Other settings

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -7,3 +7,5 @@ vsftpd_packages:
 vsftpd_service: vsftpd
 
 vsftpd_config_file: /etc/vsftpd.conf
+
+vsftpd_userlist_file: /etc/vsftpd.user_list

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -8,3 +8,5 @@ vsftpd_packages:
 vsftpd_service: vsftpd
 
 vsftpd_config_file: /etc/vsftpd/vsftpd.conf
+
+vsftpd_userlist_file: /etc/vsftpd/user_list


### PR DESCRIPTION
Beste meneer Van Vreckem,

Toen ik voor mijn taak van elnx vsftpd moest gebruiken heb ik gemerkt (met meneer Van Maele) dat ik met de standaard variablen van de role niet kon voorkomen dat gebruikers uit hun share gaan in ftp en zo andere belangrijke informatie over de linux machine te weten konden komen en vrij konden rondneuzen.

Na de [manpage van vsftpd.conf](http://vsftpd.beasts.org/vsftpd_conf.html) te lezen vond ik de variable `chroot_local_user` waarmee de gebruikers na inloggen in een _chroot() jail_ in hun home directory terecht komen. Natuurlijk kon ik dit ook met `vsftpd_options` toevoegen maar ik dacht dat dit wel handig was om standaard bij de ansible variables te hebben. Het was echter niet veel werk om dit toe te voegen aangezien ik toch al iets anders wou toevoegen aan deze role.

Wat mij bij het volgende punt brengt: de white- of blacklist optie. Toen ik door de manpage ging heb ik nog twee interessante variablen gevonden namelijk `userlist_deny` en `userlist_enable`. Deze maken het mogelijk om enkel gebruikers toegang te geven die gedefinieerd zijn in de `userlist_file`. Aangezien deze users in een ander bestand worden gedefinieerd kan dit niet zomaar met de `vsftpd_options` geconfigureerd worden, waardoor dit mij wel een waardige toevoeging leek.

De changes zijn niet duidelijk zichtbaar in het pullrequest zelfs dus daarom heb ik [deze afbeelding](https://drive.google.com/file/d/1e_KtilLB60ClrWo2khtGPreGDVVA5vlK/view?usp=sharing) gamaakt om duidelijk te maken wat waar veranderd is.


**Hoe werkt de whitelist:**

Als er een template toegekent wordt aan de variable `vsftpd_userlist` zal deze aangemaakt worden in de _Install userlist file task_ op de locatie van `vsftpd_userlist_file` (Debian+RedHat supported). 

Standaard zal de userlist als een whitelist gebruikt worden maar dit kan op blacklist worden gezet door de variable `vsftpd_userlist_whitelist` op false te zetten.

De implementatie van de whitelist heeft verder geen impact op de vsftpd server als er de variable `vsftpd_userlist` niet gedefinieerd is.


**Hoe werkt vsftpd_chroot_local_user:**

Standaard zal `vsftpd_chroot_local_user: ` op false staan, gedefinieerd in `defaults\main.yml`. Indien `vsftpd_chroot_local_user: ` op true wordt gezet zullen de gebruikers na inloggen niet uit de folder gedefinieerd door `vsftpd_local_root: /srv/shares/` kunnen navigeren.


**Getest?**

Zowel de whitelist, blacklist en de chroot() jail zijn volledig getest (en toegepast) op mijn avalon.lan fileserver.